### PR TITLE
fix: misalignment of Event emit_to args

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -124,7 +124,7 @@ pub trait Event: NamedType {
     {
         let meta = get_meta!(handle);
 
-        handle.emit_to(&meta.wrap_with_plugin(Self::NAME), label, self)
+        handle.emit_to(label, &meta.wrap_with_plugin(Self::NAME), self)
     }
 
     fn trigger_global<R: Runtime>(self, handle: &impl Manager<R>)


### PR DESCRIPTION
The window and event labels were mixed up when passed to the tauri app handle, causing the event to be emitted to the event label, rather than the window.


As per https://docs.rs/tauri/latest/tauri/trait.Manager.html#method.emit_to the window `label` should be the first argument in the `handle.emit_to`, and the `event` should be the second, but these were incorrectly reversed.