### PR TITLE
remove tauri-specta plugin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-default = []
 javascript = ["specta/typescript", "specta/js_doc"]
 typescript = ["specta/typescript", "specta/js_doc"]
 

--- a/examples/app/src-tauri/src/main.rs
+++ b/examples/app/src-tauri/src/main.rs
@@ -55,8 +55,8 @@ pub struct DemoEvent(String);
 pub struct EmptyEvent;
 
 fn main() {
-    let specta_builder = {
-        let specta_builder = ts::builder()
+    let (invoke_handler, register_events) = {
+        let builder = ts::builder()
             .commands(tauri_specta::collect_commands![
                 hello_world,
                 goodbye_world,
@@ -68,14 +68,16 @@ fn main() {
             .config(specta::ts::ExportConfig::default().formatter(specta::ts::formatter::prettier));
 
         #[cfg(debug_assertions)]
-        let specta_builder = specta_builder.path("../src/bindings.ts");
+        let builder = builder.path("../src/bindings.ts");
 
-        specta_builder.into_plugin()
+        builder.build().unwrap()
     };
 
     tauri::Builder::default()
-        .plugin(specta_builder)
+        .invoke_handler(invoke_handler)
         .setup(|app| {
+            register_events(app);
+
             let handle = app.handle();
 
             DemoEvent::listen_global(&handle, |event| {

--- a/examples/app/src/bindings.ts
+++ b/examples/app/src/bindings.ts
@@ -7,24 +7,24 @@
  * !!!!
  */
 async helloWorld(myName: string) : Promise<string> {
-return await TAURI_INVOKE("plugin:tauri-specta|hello_world", { myName });
+return await TAURI_INVOKE("hello_world", { myName });
 },
 async goodbyeWorld() : Promise<string> {
-return await TAURI_INVOKE("plugin:tauri-specta|goodbye_world");
+return await TAURI_INVOKE("goodbye_world");
 },
 async hasError() : Promise<__Result__<string, number>> {
 try {
-    return { status: "ok", data: await TAURI_INVOKE("plugin:tauri-specta|has_error") };
+    return { status: "ok", data: await TAURI_INVOKE("has_error") };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
 }
 },
 async someStruct() : Promise<MyStruct> {
-return await TAURI_INVOKE("plugin:tauri-specta|some_struct");
+return await TAURI_INVOKE("some_struct");
 },
 async generic() : Promise<null> {
-return await TAURI_INVOKE("plugin:tauri-specta|generic");
+return await TAURI_INVOKE("generic");
 }
 }
 
@@ -32,8 +32,8 @@ export const events = __makeEvents__<{
 demoEvent: DemoEvent,
 emptyEvent: EmptyEvent
 }>({
-demoEvent: "plugin:tauri-specta:demo-event",
-emptyEvent: "plugin:tauri-specta:empty-event"
+demoEvent: "demo-event",
+emptyEvent: "empty-event"
 })
 
 /** user-defined types **/
@@ -44,7 +44,7 @@ export type MyStruct = { some_field: string }
 
 /** tauri-specta globals **/
 
-         import { invoke as TAURI_INVOKE } from "@tauri-apps/api";
+         import { invoke as TAURI_INVOKE } from "@tauri-apps/api/tauri";
 import * as TAURI_API_EVENT from "@tauri-apps/api/event";
 import { type WebviewWindowHandle as __WebviewWindowHandle__ } from "@tauri-apps/api/window";
 
@@ -60,7 +60,7 @@ type __EventObj__<T> = {
     : (payload: T) => ReturnType<typeof TAURI_API_EVENT.emit>;
 };
 
-type __Result__<T, E> =
+export type __Result__<T, E> =
   | { status: "ok"; data: T }
   | { status: "error"; error: E };
 

--- a/examples/custom-plugin/plugin/package.json
+++ b/examples/custom-plugin/plugin/package.json
@@ -1,14 +1,7 @@
 {
   "name": "tauri-specta-custom-plugin",
   "private": true,
-  "exports": {
-    "./package.json": "./package.json",
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "default": "./dist/index.js"
-    }
-  },
+  "main": "index.ts",
   "scripts": {
     "postinstall": "pnpm build",
     "build": "pnpm tsc",

--- a/examples/custom-plugin/plugin/src/lib.rs
+++ b/examples/custom-plugin/plugin/src/lib.rs
@@ -25,14 +25,15 @@ macro_rules! specta_builder {
 const PLUGIN_NAME: &str = "custom-plugin";
 
 pub fn init<R: Runtime>() -> TauriPlugin<R> {
-    let plugin_utils = specta_builder!().into_plugin_utils(PLUGIN_NAME);
+    let (invoke_handler, register_events) =
+        specta_builder!().build_plugin_utils(PLUGIN_NAME).unwrap();
 
     Builder::new(PLUGIN_NAME)
-        .invoke_handler(plugin_utils.invoke_handler)
+        .invoke_handler(invoke_handler)
         .setup(move |app| {
-            let app = app.clone();
-            (plugin_utils.setup)(&app);
+            register_events(app);
 
+            let app = app.clone();
             std::thread::spawn(move || loop {
                 RandomNumber(rand::random()).emit_all(&app).unwrap();
                 std::thread::sleep(std::time::Duration::from_secs(1));

--- a/src/event.rs
+++ b/src/event.rs
@@ -11,13 +11,14 @@ use crate::PluginName;
 
 #[derive(Clone, Copy)]
 pub struct EventRegistryMeta {
-    plugin_name: PluginName,
+    plugin_name: Option<PluginName>,
 }
 
 impl EventRegistryMeta {
     fn wrap_with_plugin(&self, input: &str) -> String {
         self.plugin_name
-            .apply_as_prefix(input, crate::ItemType::Event)
+            .map(|n| n.apply_as_prefix(input, crate::ItemType::Event))
+            .unwrap_or_else(|| input.to_string())
     }
 }
 
@@ -40,7 +41,11 @@ impl EventCollection {
 pub(crate) struct EventRegistry(pub(crate) RwLock<BTreeMap<SpectaID, EventRegistryMeta>>);
 
 impl EventRegistry {
-    pub fn register_collection(&self, collection: EventCollection, plugin_name: PluginName) {
+    pub fn register_collection(
+        &self,
+        collection: EventCollection,
+        plugin_name: Option<PluginName>,
+    ) {
         let mut registry = self.0.write().expect("Failed to write EventRegistry");
 
         registry.extend(

--- a/src/globals.js
+++ b/src/globals.js
@@ -1,4 +1,4 @@
-import { invoke as TAURI_INVOKE } from "@tauri-apps/api";
+import { invoke as TAURI_INVOKE } from "@tauri-apps/api/tauri";
 import * as TAURI_API_EVENT from "@tauri-apps/api/event";
 
 /** @typedef {typeof import("@tauri-apps/api/window").WebviewWindowHandle} __WebviewWindowHandle__ */

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -1,4 +1,4 @@
-import { invoke as TAURI_INVOKE } from "@tauri-apps/api";
+import { invoke as TAURI_INVOKE } from "@tauri-apps/api/tauri";
 import * as TAURI_API_EVENT from "@tauri-apps/api/event";
 import { type WebviewWindowHandle as __WebviewWindowHandle__ } from "@tauri-apps/api/window";
 
@@ -14,7 +14,7 @@ type __EventObj__<T> = {
     : (payload: T) => ReturnType<typeof TAURI_API_EVENT.emit>;
 };
 
-type __Result__<T, E> =
+export type __Result__<T, E> =
   | { status: "ok"; data: T }
   | { status: "error"; error: E };
 

--- a/src/js.rs
+++ b/src/js.rs
@@ -7,8 +7,8 @@ use tauri::Runtime;
 /// Implements [`ExportLanguage`] for JS exporting
 pub struct Language;
 
-pub fn builder<TRuntime: Runtime>() -> PluginBuilder<Language, NoCommands<TRuntime>, NoEvents> {
-    PluginBuilder::default()
+pub fn builder<TRuntime: Runtime>() -> Builder<Language, NoCommands<TRuntime>, NoEvents> {
+    Builder::default()
 }
 
 pub const GLOBALS: &str = include_str!("./globals.js");

--- a/src/js_ts.rs
+++ b/src/js_ts.rs
@@ -121,7 +121,8 @@ pub fn handle_result(
 pub fn command_body(cfg: &ExportConfig, function: &FunctionDataType, as_any: bool) -> String {
     let name = cfg
         .plugin_name
-        .apply_as_prefix(&function.name, ItemType::Command);
+        .map(|n| n.apply_as_prefix(&function.name, ItemType::Command))
+        .unwrap_or_else(|| function.name.to_string());
 
     maybe_return_as_result_tuple(
         &tauri_invoke(&name, arg_usages(&arg_names(&function.args))),
@@ -134,7 +135,10 @@ pub fn events_map(events: &[EventDataType], cfg: &ExportConfig) -> String {
     events
         .iter()
         .map(|event| {
-            let name_str = cfg.plugin_name.apply_as_prefix(event.name, ItemType::Event);
+            let name_str = cfg
+                .plugin_name
+                .map(|n| n.apply_as_prefix(event.name, ItemType::Event))
+                .unwrap_or_else(|| event.name.to_string());
             let name_camel = event.name.to_lower_camel_case();
 
             format!(r#"{name_camel}: "{name_str}""#)

--- a/src/ts.rs
+++ b/src/ts.rs
@@ -12,8 +12,8 @@ use tauri::Runtime;
 /// Implements [`ExportLanguage`] for TypeScript exporting
 pub struct Language;
 
-pub fn builder<TRuntime: Runtime>() -> PluginBuilder<Language, NoCommands<TRuntime>, NoEvents> {
-    PluginBuilder::default()
+pub fn builder<TRuntime: Runtime>() -> Builder<Language, NoCommands<TRuntime>, NoEvents> {
+    Builder::default()
 }
 
 pub const GLOBALS: &str = include_str!("./globals.ts");


### PR DESCRIPTION
The plugin approach was cool but in tauri v2 [command permissions](https://beta.tauri.app/concepts/security/permissions/) don't really work when we proxy user commands through a plugin, since they get detected differently by [tauri's ACL checks](https://github.com/tauri-apps/tauri/blob/8276ab767b3d3d9f3252c8eb9255da7afa67ae31/core/tauri/src/webview/mod.rs#L1156-L1162).