### PR TITLE
Updated tauri dep to `>= beta 19` to fix `link_swift_library` is private

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ tauri-specta-macros = { version = "=2.0.0-rc.5", path = "./macros" }
 serde = "1"
 serde_json = "1"
 thiserror = "1"
-tauri = { version = "=2.0.0-beta.19", no-default-features = true, features = [
+tauri = { version = ">=2.0.0-beta.19", no-default-features = true, features = [
     "specta",
 ] }
 


### PR DESCRIPTION
The function `link_swift_library` has been replaced by `link_apple_library` in `tauri-util`. However, `tauri-specta` has a fixed version dependency on tauri version =2.0.0-beta.19, causing a version mismatch among the tauri crates. This results in the following error:

`error[E0603]: function `link_swift_library` is private.`

Updated the tauri version dependency to `>=2.0.0-beta.19`
