### PR TITLE
Allow paths in collect_events macro

### DIFF
--- a/examples/app/src-tauri/src/main.rs
+++ b/examples/app/src-tauri/src/main.rs
@@ -127,7 +127,7 @@ fn main() {
                 typesafe_errors_using_thiserror,
                 typesafe_errors_using_thiserror_with_value
             ])
-            .events(tauri_specta::collect_events![DemoEvent, EmptyEvent])
+            .events(tauri_specta::collect_events![crate::DemoEvent, EmptyEvent])
             .types(TypeCollection::default().register::<Custom>())
             .config(specta::ts::ExportConfig::default().formatter(specta::ts::formatter::prettier))
             .types(TypeCollection::default().register::<Testing>())

--- a/src/event.rs
+++ b/src/event.rs
@@ -186,7 +186,7 @@ pub type CollectEventsTuple = (EventCollection, Vec<EventDataType>, specta::Type
 
 #[macro_export]
 macro_rules! collect_events {
-    ($($event:ident),* $(,)?) => {{
+    ($($event:path),* $(,)?) => {{
     	let mut collection: $crate::EventCollection = ::core::default::Default::default();
 
      	$(collection.register::<$event>();)*


### PR DESCRIPTION
This PR allows paths to be passed to the `collect_events![]` macro, not just idents. Note the example usage in `/home/jsimonrichard/Trellis/tauri-specta/examples/app/src-tauri/src/main.rs:130`.