### PR TITLE
Fail test when something goes wrong

### DIFF
--- a/examples/custom-plugin/plugin/src/lib.rs
+++ b/examples/custom-plugin/plugin/src/lib.rs
@@ -56,6 +56,6 @@ mod test {
             .path("./bindings.ts")
             .config(specta::ts::ExportConfig::default().formatter(specta::ts::formatter::prettier))
             .export_for_plugin(PLUGIN_NAME)
-            .ok();
+            .expect("failed to export specta types");
     }
 }


### PR DESCRIPTION
This makes the `export_types` test fail when something goes wrong instead of failing silently.

This is especially important because these failures sometimes result in no export at all (and the user needs to know why).