### PR TITLE
fix: add `@ts-ignore` comment

### DIFF
--- a/src/lang/globals.ts
+++ b/src/lang/globals.ts
@@ -1,5 +1,7 @@
 import {
+	// @ts-ignore
 	invoke as TAURI_INVOKE,
+	// @ts-ignore
 	Channel as TAURI_CHANNEL,
 } from "@tauri-apps/api/core";
 import * as TAURI_API_EVENT from "@tauri-apps/api/event";
@@ -21,6 +23,7 @@ export type Result<T, E> =
 	| { status: "ok"; data: T }
 	| { status: "error"; error: E };
 
+// @ts-ignore
 function __makeEvents__<T extends Record<string, any>>(
 	mappings: Record<keyof T, string>,
 ) {


### PR DESCRIPTION
TypeScript reports an error when [`noUnusedLocals`](https://www.typescriptlang.org/tsconfig/#noUnusedLocals) is enabled and `TAURI_INVOKE`, `TAURI_CHANNEL` or `__makeEvents__` are not being used. I found myself often adding a [`@ts-ignore`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-6.html#suppress-errors-in-ts-files-using--ts-ignore-comments).

It's in fact a very minor inconvenience, but I think this would be a good addition and shouldn't cause any problems.