### PR TITLE
fix: remove tauri::ipc::Channel type from generated type set

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -141,8 +141,13 @@ impl<R: Runtime> Builder<R> {
     /// let mut builder = Builder::<tauri::Wry>::new().commands(collect_commands![hello_world]);
     /// ```
     pub fn commands(mut self, commands: Commands<R>) -> Self {
+        let command_types = (commands.1)(&mut self.types);
+
+        self.types
+            .remove(<tauri::ipc::Channel<()> as specta::NamedType>::sid());
+
         Self {
-            command_types: (commands.1)(&mut self.types),
+            command_types,
             commands,
             ..self
         }


### PR DESCRIPTION
After collecting types from all the commands, make sure to remove the type for `tauri::ipc::Channel` as it may be present if any command took the channel as argument.

Until this addition the user would generate the TAURI_CHANNEL type in their bindings if they called `.events()` and then `.commands()` in this order.

The call to `.events()` tried to remove this type, but it got added later in the call to `.commands()`.

this fixes: #171 