### PR TITLE
fix(tauri): correct plugin command and event naming for v2

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -9,6 +9,8 @@ use serde::{Serialize, de::DeserializeOwned};
 use specta::{Type, Types, datatype::Reference};
 use tauri::{Emitter, EventId, EventTarget, Listener, Manager, Runtime};
 
+use crate::name::resolve_tauri_event_name;
+
 /// A wrapper around the output of the `collect_commands` macro.
 ///
 /// This acts to seal the implementation details of the macro.
@@ -38,9 +40,7 @@ impl EventRegistry {
             .get(&TypeId::of::<E>())
             .unwrap_or_else(|| panic!("Event {} not found in registry!", E::NAME));
 
-        meta.plugin_name
-            .map(|plugin_name| format!("plugin:{plugin_name}:{}", E::NAME).into())
-            .unwrap_or_else(|| E::NAME.into())
+        resolve_tauri_event_name(meta.plugin_name, E::NAME)
     }
 
     pub fn get_or_manage<R: Runtime>(handle: &impl Manager<R>) -> tauri::State<'_, Self> {

--- a/src/lang/js_ts.rs
+++ b/src/lang/js_ts.rs
@@ -7,6 +7,7 @@ use specta_serde::Phase;
 use specta_tags::TransformPlan;
 use specta_typescript::{Error, Exporter, FrameworkExporter, define};
 
+use crate::name::{resolve_tauri_command_name, resolve_tauri_event_name};
 use crate::{BuilderConfiguration, ErrorHandlingMode, LanguageExt};
 
 impl LanguageExt for specta_typescript::Typescript {
@@ -159,12 +160,9 @@ fn runtime(
         for command in &cfg.commands {
             validate_exported_command(command, exporter.types)?;
 
-            let command_name_escaped = serde_json::to_string(
-                &cfg.plugin_name
-                    .map(|plugin_name| format!("plugin|{plugin_name}|{}", command.name()).into())
-                    .unwrap_or_else(|| command.name().clone()),
-            )
-            .expect("failed to serialize string");
+            let command_name_escaped =
+                serde_json::to_string(&resolve_tauri_command_name(cfg.plugin_name, command.name()))
+                    .expect("failed to serialize string");
 
             let arguments = command
                 .args()
@@ -351,12 +349,9 @@ fn runtime(
     if enabled_events {
         let mut s = Struct::named();
         for (name, (_, r)) in &cfg.events {
-            let event_name_escaped = serde_json::to_string(
-                &cfg.plugin_name
-                    .map(|plugin_name| format!("plugin:{plugin_name}:{name}"))
-                    .unwrap_or_else(|| name.to_string()),
-            )
-            .expect("failed to serialize string");
+            let event_name_escaped =
+                serde_json::to_string(&resolve_tauri_event_name(cfg.plugin_name, name))
+                    .expect("failed to serialize string");
 
             let mut field_ts = "makeEvent".to_string();
             if !jsdoc {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,6 +186,7 @@ mod commands;
 mod event;
 mod lang;
 mod macros;
+mod name;
 
 pub use builder::{Builder, BuilderConfiguration, ErrorHandlingMode};
 pub use commands::Commands;

--- a/src/name.rs
+++ b/src/name.rs
@@ -1,0 +1,65 @@
+use std::borrow::Cow;
+
+pub(crate) fn resolve_tauri_command_name<'a>(
+    plugin_name: Option<&'a str>,
+    name: &'a str,
+) -> Cow<'a, str> {
+    resolve_tauri_name(plugin_name, name, TauriNameType::Command)
+}
+
+pub(crate) fn resolve_tauri_event_name<'a>(
+    plugin_name: Option<&'a str>,
+    name: &'a str,
+) -> Cow<'a, str> {
+    resolve_tauri_name(plugin_name, name, TauriNameType::Event)
+}
+enum TauriNameType {
+    Event,
+    Command,
+}
+
+fn resolve_tauri_name<'a>(
+    plugin_name: Option<&'a str>,
+    name: &'a str,
+    name_type: TauriNameType,
+) -> Cow<'a, str> {
+    match plugin_name {
+        Some(p) => resolve_tauri_plugin_name(p, name, name_type),
+        None => Cow::Borrowed(name),
+    }
+}
+
+fn resolve_tauri_plugin_name(
+    plugin_name: &str,
+    name: &str,
+    name_type: TauriNameType,
+) -> Cow<'static, str> {
+    let delimiter = match name_type {
+        TauriNameType::Event => ":",
+        TauriNameType::Command => "|",
+    };
+    Cow::Owned(format!("plugin:{plugin_name}{delimiter}{name}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_resolve_tauri_command_name() {
+        assert_eq!(resolve_tauri_command_name(None, "my_command"), "my_command");
+        assert_eq!(
+            resolve_tauri_command_name(Some("my_plugin"), "my_command"),
+            "plugin:my_plugin|my_command"
+        );
+    }
+
+    #[test]
+    fn test_resolve_tauri_event_name() {
+        assert_eq!(resolve_tauri_event_name(None, "my_event"), "my_event");
+        assert_eq!(
+            resolve_tauri_event_name(Some("my_plugin"), "my_event"),
+            "plugin:my_plugin:my_event"
+        );
+    }
+}


### PR DESCRIPTION
### Description

Fixed incorrect plugin command and event naming convention for Tauri v2. According to the [official Tauri v2 documentation](https://v2.tauri.app/develop/plugins/#adding-commands), the format for plugin commands must be `plugin:<plugin_name>|function_name`.

### Changes
* **Restored and refactored** the `resolve_tauri_name` logic to align with the stable Tauri v2 API.
* **Format Correction**: 
    * Commands now use `plugin:name|command`.
    * Events now use `plugin:name:event`.
* **Performance Optimization**: Switched to `Cow<'a, str>` for name resolution to avoid unnecessary heap allocations when no plugin prefix is present.

### References
* Tauri v2 Plugin Commands: [https://v2.tauri.app/develop/plugins/#adding-commands](https://v2.tauri.app/develop/plugins/#adding-commands)