### PR TITLE
Document tauri-specta-query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3437,6 +3437,7 @@ dependencies = [
  "serde",
  "serde_json",
  "specta",
+ "specta-typescript",
  "tauri",
  "tauri-specta",
 ]

--- a/crates/tauri-specta-query/Cargo.toml
+++ b/crates/tauri-specta-query/Cargo.toml
@@ -12,5 +12,9 @@ serde = "1"
 serde_json = "1"
 tauri-specta = { path = "../.." }
 
+[dev-dependencies]
+specta-typescript.workspace = true
+tauri-specta = { path = "../..", features = ["typescript"] }
+
 [lints]
 workspace = true

--- a/crates/tauri-specta-query/src/lib.rs
+++ b/crates/tauri-specta-query/src/lib.rs
@@ -1,7 +1,104 @@
-//! TODO
+//! Generate [TanStack Query](https://tanstack.com/query/latest) helpers for
+//! commands exported by [`tauri-specta`](https://docs.rs/tauri-specta).
 //!
-//! Known Issues:
-//!  - You can assign commands, events, types, constants after `From` into builder which will override. Fine for now.
+//! This crate lets a Tauri application classify its commands as either
+//! **queries** (operations that read data) or **mutations** (operations that
+//! change data). [`CommandSet`] combines both groups into one Tauri invoke
+//! handler and generates framework-specific query options, mutation options,
+//! and cache keys alongside the normal `tauri-specta` bindings.
+//!
+//! # Backend setup
+//!
+//! Annotate commands with both `#[tauri::command]` and `#[specta::specta]`, then
+//! pass separate command collections to [`CommandSet::new`]. The string returned
+//! by [`CommandSet::build`] must be supplied to the TypeScript exporter with
+//! `Typescript::with_raw`.
+//!
+//! ```rust,no_run
+//! use specta_typescript::Typescript;
+//! use tauri_specta::collect_commands;
+//! use tauri_specta_query::{CommandSet, TanstackQueryFramework};
+//!
+//! #[tauri::command]
+//! #[specta::specta]
+//! fn get_user(id: u32) -> String {
+//!     format!("user-{id}")
+//! }
+//!
+//! #[tauri::command]
+//! #[specta::specta]
+//! fn rename_user(id: u32, name: String) {
+//!     // Update the user in your application state.
+//! }
+//!
+//! let commands = CommandSet::<tauri::Wry>::new(
+//!     collect_commands![get_user],
+//!     collect_commands![rename_user],
+//! );
+//! let (query_bindings, builder) = commands.build(TanstackQueryFramework::React);
+//!
+//! #[cfg(debug_assertions)]
+//! builder
+//!     .export(
+//!         Typescript::default().with_raw(query_bindings),
+//!         "../src/bindings.ts",
+//!     )
+//!     .expect("failed to export bindings");
+//!
+//! tauri::Builder::default()
+//!     .invoke_handler(builder.invoke_handler())
+//!     .setup(move |app| {
+//!         builder.mount_events(app);
+//!         Ok(())
+//!     });
+//! ```
+//!
+//! In a complete application, finish the Tauri builder with `run` as usual.
+//!
+//! # Frontend usage
+//!
+//! The generated module exports four objects:
+//!
+//! - `queries`, whose methods accept the same arguments as the corresponding
+//!   command and return query options;
+//! - `mutations`, whose zero-argument methods return mutation options;
+//! - `queryKeys`, for matching or invalidating query caches (its arguments are
+//!   partial, so prefixes can be constructed); and
+//! - `mutationKeys`, for matching mutation caches.
+//!
+//! For React Query, the commands above can be consumed like this:
+//!
+//! ```tsx
+//! import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+//! import { mutations, queries, queryKeys } from "./bindings";
+//!
+//! const user = useQuery(queries.getUser(1));
+//! const queryClient = useQueryClient();
+//! const renameUser = useMutation({
+//!   ...mutations.renameUser(),
+//!   onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.getUser(1) }),
+//! });
+//!
+//! renameUser.mutate({ id: 1, name: "Ada" });
+//! ```
+//!
+//! Command names and argument names are converted to `lowerCamelCase` in the
+//! generated TypeScript. Mutation arguments are passed to `mutate` as one object;
+//! a mutation command with no arguments instead receives no input.
+//!
+//! # Frameworks
+//!
+//! Choose the matching [`TanstackQueryFramework`] variant for React, Solid, Vue,
+//! Angular, Svelte, or Preact. The generated helpers use that framework's
+//! TanStack Query package. Svelte helpers return option-producing functions and
+//! do not generate an import.
+//!
+//! # Additional bindings
+//!
+//! Register events, standalone types, and constants on [`CommandSet`] before
+//! calling [`CommandSet::build`]. The returned `tauri_specta::Builder` can then
+//! be configured further—for example with semantic types—before it is exported
+//! and mounted.
 
 use std::{borrow::Cow, collections::BTreeMap, sync::Arc};
 
@@ -11,6 +108,10 @@ use specta::{Type, Types, datatype};
 use tauri::{Runtime, ipc::Invoke};
 use tauri_specta::{Commands, Events};
 
+/// A collection of query commands, mutation commands, and their shared bindings.
+///
+/// Build a command set with [`CommandSet::new`], optionally register additional
+/// bindings, and finish it with [`CommandSet::build`].
 pub struct CommandSet<R: Runtime> {
     handler: Arc<dyn Fn(Invoke<R>) -> bool + Send + Sync + 'static>,
     queries: Vec<datatype::Function>,
@@ -21,6 +122,11 @@ pub struct CommandSet<R: Runtime> {
 }
 
 impl<R: Runtime> CommandSet<R> {
+    /// Creates a command set from query commands and mutation commands.
+    ///
+    /// Both arguments are normally created with
+    /// [`tauri_specta::collect_commands!`]. A command should appear in only one
+    /// collection so it receives one unambiguous set of generated helpers.
     pub fn new(queries: Commands<R>, mutations: Commands<R>) -> Self {
         let Commands(query_invoke, query_types) = queries;
         let Commands(mutation_invoke, mutation_types) = mutations;
@@ -45,20 +151,43 @@ impl<R: Runtime> CommandSet<R> {
         }
     }
 
+    /// Registers the events to include in the generated bindings.
+    ///
+    /// This replaces events previously assigned to the command set.
+    #[must_use]
     pub fn events(self, events: Events) -> Self {
         Self { events, ..self }
     }
 
+    /// Replaces the type registry used by this command set.
+    ///
+    /// Prefer [`CommandSet::typ`] when adding individual standalone types. This
+    /// method replaces the registry populated from the query and mutation
+    /// commands, so the supplied registry must contain every required type.
+    #[must_use]
     pub fn types(self, types: Types) -> Self {
         Self { types, ..self }
     }
 
+    /// Registers a standalone Specta type in the generated bindings.
+    ///
+    /// Use this for types that are not already reachable from a command or
+    /// event. It can be chained multiple times.
+    #[must_use]
     pub fn typ<T: Type>(mut self) -> Self {
         self.types.register_mut::<T>();
         self
     }
 
+    /// Adds a serializable constant to the generated bindings.
+    ///
+    /// Assigning the same key more than once retains the last value.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `value` cannot be represented as a [`serde_json::Value`].
     #[track_caller]
+    #[must_use]
     pub fn constant<T: Serialize>(mut self, k: impl Into<Cow<'static, str>>, v: T) -> Self {
         self.constants.insert(
             k.into(),
@@ -67,6 +196,13 @@ impl<R: Runtime> CommandSet<R> {
         self
     }
 
+    /// Combines the commands and types from two command sets.
+    ///
+    /// # Panics
+    ///
+    /// Event and constant merging is not implemented yet, so this method
+    /// currently panics. It should not be used until that support is added.
+    #[must_use]
     pub fn merge(&self, other: &Self) -> Self {
         let mut types = self.types.clone();
         types.extend(&other.types);
@@ -97,6 +233,14 @@ impl<R: Runtime> CommandSet<R> {
         }
     }
 
+    /// Generates TanStack Query helpers and constructs the Tauri Specta builder.
+    ///
+    /// The returned string is a raw TypeScript fragment. Pass it to
+    /// `specta_typescript::Typescript::with_raw` (or `JSDoc::with_raw`) when
+    /// exporting the returned builder. The builder owns the combined invoke
+    /// handler and must also be supplied to Tauri with
+    /// [`tauri_specta::Builder::invoke_handler`].
+    #[must_use]
     pub fn build(self, framework: TanstackQueryFramework) -> (String, tauri_specta::Builder<R>) {
         let output = {
             let mut output = format!("/** Tanstack Query */\n{}\n", framework.import());
@@ -223,14 +367,23 @@ impl<R: Runtime> CommandSet<R> {
     }
 }
 
+/// The frontend framework targeted by the generated TanStack Query helpers.
+///
+/// [`React`](Self::React) is the default.
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TanstackQueryFramework {
+    /// React, using `@tanstack/react-query`.
     #[default]
     React,
+    /// Solid, using `@tanstack/solid-query`.
     Solid,
+    /// Vue, using `@tanstack/vue-query`.
     Vue,
+    /// Angular, using `@tanstack/angular-query-experimental`.
     Angular,
+    /// Svelte, emitting option-producing functions without an import.
     Svelte,
+    /// Preact, using `@tanstack/preact-query`.
     Preact,
 }
 


### PR DESCRIPTION
## Summary

- replace the placeholder crate docs with a complete backend setup guide
- add React Query frontend examples for queries, mutations, and cache invalidation
- document all public APIs and supported TanStack Query framework variants
- compile-check the backend rustdoc example with development dependencies

## Why

`tauri-specta-query` did not explain how to classify commands, inject its generated helpers into exported bindings, or consume those helpers on the frontend. Its public API also lacked rustdoc coverage.

## Impact

Users now get an end-to-end, compile-checked setup example and clear reference documentation for generated helpers, naming behavior, additional bindings, and framework selection.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p tauri-specta-query --doc`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p tauri-specta-query --no-deps`
- `git diff --check`