### PR TITLE
Preserve named type references inside Option

### DIFF
--- a/src/lang/js_ts.rs
+++ b/src/lang/js_ts.rs
@@ -1000,11 +1000,98 @@ fn render_reference_dt(dt: &DataType, exporter: &FrameworkExporter) -> Result<St
         };
         Ok(format!("Channel<{generic}>"))
     } else {
-        match &dt {
+        match dt {
             DataType::Reference(r) => exporter.reference(r),
-            dt => exporter.inline(dt),
+            dt => {
+                // `FrameworkExporter::inline` expands named references nested inside nullable
+                // types. Render those references first and protect them as opaque TypeScript so
+                // `Option<Thing>` remains `Thing | null`, while explicitly inline types still
+                // expand as requested.
+                let mut rules = Vec::new();
+                collect_named_reference_rules(dt, exporter, &mut rules)?;
+                let dt = rules
+                    .into_iter()
+                    .fold(Remapper::new(), |remapper, (from, to)| {
+                        remapper.rule(from, to)
+                    })
+                    .remap_dt(dt.clone());
+                exporter.inline(&dt)
+            }
         }
     }
+}
+
+fn collect_named_reference_rules(
+    dt: &DataType,
+    exporter: &FrameworkExporter,
+    rules: &mut Vec<(DataType, DataType)>,
+) -> Result<(), Error> {
+    match dt {
+        DataType::Primitive(_) | DataType::Generic(_) => {}
+        DataType::List(list) => collect_named_reference_rules(&list.ty, exporter, rules)?,
+        DataType::Map(map) => {
+            collect_named_reference_rules(map.key_ty(), exporter, rules)?;
+            collect_named_reference_rules(map.value_ty(), exporter, rules)?;
+        }
+        DataType::Struct(s) => {
+            collect_named_reference_rules_from_fields(&s.fields, exporter, rules)?
+        }
+        DataType::Enum(e) => {
+            for (_, variant) in &e.variants {
+                collect_named_reference_rules_from_fields(&variant.fields, exporter, rules)?;
+            }
+        }
+        DataType::Tuple(tuple) => {
+            for dt in &tuple.elements {
+                collect_named_reference_rules(dt, exporter, rules)?;
+            }
+        }
+        DataType::Nullable(dt) => collect_named_reference_rules(dt, exporter, rules)?,
+        DataType::Intersection(dts) => {
+            for dt in dts {
+                collect_named_reference_rules(dt, exporter, rules)?;
+            }
+        }
+        DataType::Reference(Reference::Named(r)) => match &r.inner {
+            NamedReferenceType::Reference { .. } => rules.push((
+                dt.clone(),
+                define(exporter.reference(&Reference::Named(r.clone()))?).into(),
+            )),
+            NamedReferenceType::Inline { dt, .. } => {
+                collect_named_reference_rules(dt, exporter, rules)?;
+            }
+            NamedReferenceType::Recursive(_) => {}
+        },
+        DataType::Reference(Reference::Opaque(_)) => {}
+    }
+
+    Ok(())
+}
+
+fn collect_named_reference_rules_from_fields(
+    fields: &Fields,
+    exporter: &FrameworkExporter,
+    rules: &mut Vec<(DataType, DataType)>,
+) -> Result<(), Error> {
+    let fields: Vec<&DataType> = match fields {
+        Fields::Unit => return Ok(()),
+        Fields::Unnamed(fields) => fields
+            .fields
+            .iter()
+            .filter_map(|field| field.ty.as_ref())
+            .collect(),
+        Fields::Named(fields) => fields
+            .fields
+            .iter()
+            .filter_map(|(_, field)| field.ty.as_ref())
+            .collect(),
+    };
+
+    for dt in fields {
+        collect_named_reference_rules(dt, exporter, rules)?;
+    }
+
+    Ok(())
 }
 
 const RESERVED_NDT_NAMES: &[&str] = &[

--- a/tests/option_type_references.rs
+++ b/tests/option_type_references.rs
@@ -1,0 +1,66 @@
+#![allow(missing_docs)]
+
+use specta::Type;
+use tauri_specta::{Builder, collect_commands};
+
+#[derive(serde::Serialize, serde::Deserialize, Type)]
+struct Thing {
+    id: u32,
+    name: String,
+    tags: Vec<String>,
+}
+
+#[tauri::command]
+#[specta::specta]
+fn bare(thing: Thing) -> Thing {
+    thing
+}
+
+#[tauri::command]
+#[specta::specta]
+fn optional(thing: Option<Thing>) -> Option<Thing> {
+    thing
+}
+
+#[tauri::command]
+#[specta::specta]
+fn listed(thing: Vec<Thing>) -> Vec<Thing> {
+    thing
+}
+
+#[tauri::command]
+#[specta::specta]
+fn resulted() -> Result<Option<Thing>, String> {
+    unimplemented!()
+}
+
+#[test]
+fn named_types_inside_options_are_referenced() {
+    let path = std::env::temp_dir().join(format!(
+        "tauri-specta-option-type-references-{}.ts",
+        std::process::id()
+    ));
+
+    Builder::<tauri::Wry>::new()
+        .commands(collect_commands![bare, optional, listed, resulted])
+        .export(specta_typescript::Typescript::default(), &path)
+        .expect("bindings export should succeed");
+
+    let bindings = std::fs::read_to_string(&path).expect("bindings should be readable");
+    std::fs::remove_file(path).expect("temporary bindings should be removable");
+
+    assert!(bindings.contains("bare: (thing: Thing)"), "{bindings}");
+    assert!(
+        bindings.contains("optional: (thing: Thing | null)"),
+        "{bindings}"
+    );
+    assert!(
+        bindings.contains("__TAURI_INVOKE<Thing | null>(\"optional\""),
+        "{bindings}"
+    );
+    assert!(bindings.contains("listed: (thing: Thing[])"), "{bindings}");
+    assert!(
+        bindings.contains("typedError<Thing | null, string>("),
+        "{bindings}"
+    );
+}


### PR DESCRIPTION
## Summary

- preserve named Specta references when rendering anonymous TypeScript datatypes
- keep explicitly inline types expanded as requested
- add regression coverage for bare, optional, listed, and `Result<Option<_>, _>` command types

## Root cause

`FrameworkExporter::inline` recursively expanded a named reference nested under `DataType::Nullable`. The phase-aware serde formatter had correctly retained the reference, but rendering `Option<Thing>` as an anonymous datatype turned `Thing` back into its full inline body.

The exporter now renders nested named references first and protects those rendered references while the surrounding anonymous datatype is inlined.

Fixes #228.

## Validation

- `cargo test --features typescript --test option_type_references`
- `cargo check --all-features`
- `cargo test --all-features`
