### PR TITLE
Add query crate publish metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3431,7 +3431,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-specta-query"
-version = "0.0.0"
+version = "0.0.1"
 dependencies = [
  "heck 0.5.0",
  "serde",

--- a/crates/tauri-specta-query/Cargo.toml
+++ b/crates/tauri-specta-query/Cargo.toml
@@ -1,7 +1,20 @@
 [package]
 name = "tauri-specta-query"
+description = "Generate typesafe TanStack Query helpers for Tauri Specta commands"
 version = "0.0.1"
+authors = ["Oscar Beaumont <oscar@otbeaumont.me>"]
 edition = "2024"
+license = "MIT"
+include = ["/src"]
+repository = "https://github.com/specta-rs/tauri-specta"
+documentation = "https://docs.rs/tauri-specta-query/latest/tauri_specta_query"
+keywords = ["tauri", "specta", "tanstack-query", "typescript", "typesafe"]
+categories = ["web-programming", "asynchronous"]
+
+[package.metadata."docs.rs"]
+all-features = true
+rustc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 heck = "0.5"

--- a/crates/tauri-specta-query/src/lib.rs
+++ b/crates/tauri-specta-query/src/lib.rs
@@ -1,7 +1,20 @@
-//! TODO
+//! Generate typesafe [TanStack Query](https://tanstack.com/query) helpers from
+//! [`tauri-specta`](https://docs.rs/tauri-specta) commands.
 //!
-//! Known Issues:
-//!  - You can assign commands, events, types, constants after `From` into builder which will override. Fine for now.
+//! Queries and mutations are collected separately in a [`CommandSet`]. Building the command set
+//! produces both the TypeScript helpers for the selected [`TanstackQueryFramework`] and the
+//! [`tauri_specta::Builder`] used to register the commands with Tauri.
+//!
+//! # Known issues
+//!
+//! Commands, events, types, and constants assigned to the builder after conversion from a
+//! [`CommandSet`] override the values supplied by the command set.
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![doc(
+    // TODO: Tauri Specta logo
+    html_logo_url = "https://github.com/specta-rs/specta/raw/main/.github/logo-128.png",
+    html_favicon_url = "https://github.com/specta-rs/specta/raw/main/.github/logo-128.png"
+)]
 
 use std::{borrow::Cow, collections::BTreeMap, sync::Arc};
 


### PR DESCRIPTION
## Summary

- add crates.io and docs.rs publishing metadata for `tauri-specta-query`
- add crate-level documentation plus the shared rustdoc logo and favicon attributes
- synchronize the query crate version in `Cargo.lock`

## Why

The query crate only declared its name, version, and edition, and its crate documentation was a placeholder. These changes prepare its package metadata and generated documentation for publication.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p tauri-specta-query`
- `cargo metadata --locked --no-deps --format-version 1`
- `cargo package -p tauri-specta-query --allow-dirty --list`

A full `cargo package` dry run currently stops because the workspace pins `specta = 2.0.0-rc.26` through a Git patch while crates.io only has rc.25. That existing dependency policy is unchanged by this PR.