### PR TITLE
Fix Clippy CI reporting failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,5 @@ jobs:
         run: rustup toolchain install stable --profile minimal --component clippy
       - name: Rust cache
         uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features
+      - name: Run Clippy
+        run: cargo clippy --all-features


### PR DESCRIPTION
## What changed

- replace the archived `actions-rs/clippy-check` action with a direct `cargo clippy --all-features` command
- preserve the existing Clippy feature coverage without publishing a separate GitHub Check

## Why

Clippy completes successfully on `main`, but the old action fails afterward with `Resource not accessible by integration` while trying to publish its results through the Checks API. The action also emits warnings for its deprecated Node runtime dependencies.

Running Clippy directly makes the job result reflect Cargo's exit status and removes the failing API write.

## Validation

- `cargo clippy --all-features` (passes with 7 existing warnings)
- workflow YAML parse check
- `git diff --check`
