### PR TITLE
Simplify README test command

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,7 @@ pnpm tauri dev
 ### Running tests
 
 ```bash
-mkdir _out
-OUT_DIR="$(pwd)/_out" cargo test --all --all-features
+cargo test --all --all-features
 ```
 
 ## Credit


### PR DESCRIPTION
## Summary

- remove the manual `_out` directory setup from the contributing test instructions
- remove the explicit `OUT_DIR` override and rely on Cargo's managed build output directory

## Why

The repository does not consume a manually supplied `OUT_DIR`, and CI already runs the test suite without setting one. Removing it makes the contributing workflow simpler and avoids suggesting that contributors need to manage Cargo's output directory themselves.

## Validation

- `git diff --check`
- `cargo test --all --all-features` (Rust compilation succeeded without `OUT_DIR`; the run later stopped because `examples/tanstack-query/dist` is absent, which is unrelated to this documentation change)