### PR TITLE
Use upstream reference rendering for optional named types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2929,7 +2929,7 @@ dependencies = [
 [[package]]
 name = "specta"
 version = "2.0.0-rc.26"
-source = "git+https://github.com/specta-rs/specta.git?rev=3c535739ea7bd8737ecdbff6c3aef9b7330da706#3c535739ea7bd8737ecdbff6c3aef9b7330da706"
+source = "git+https://github.com/specta-rs/specta.git?rev=c297f26c478766d1cdec11fc804b43f98e8932ad#c297f26c478766d1cdec11fc804b43f98e8932ad"
 dependencies = [
  "bytes",
  "chrono",
@@ -2942,7 +2942,7 @@ dependencies = [
 [[package]]
 name = "specta-macros"
 version = "2.0.0-rc.26"
-source = "git+https://github.com/specta-rs/specta.git?rev=3c535739ea7bd8737ecdbff6c3aef9b7330da706#3c535739ea7bd8737ecdbff6c3aef9b7330da706"
+source = "git+https://github.com/specta-rs/specta.git?rev=c297f26c478766d1cdec11fc804b43f98e8932ad#c297f26c478766d1cdec11fc804b43f98e8932ad"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -2953,7 +2953,7 @@ dependencies = [
 [[package]]
 name = "specta-serde"
 version = "0.0.13"
-source = "git+https://github.com/specta-rs/specta.git?rev=3c535739ea7bd8737ecdbff6c3aef9b7330da706#3c535739ea7bd8737ecdbff6c3aef9b7330da706"
+source = "git+https://github.com/specta-rs/specta.git?rev=c297f26c478766d1cdec11fc804b43f98e8932ad#c297f26c478766d1cdec11fc804b43f98e8932ad"
 dependencies = [
  "specta",
  "specta-macros",
@@ -2962,7 +2962,7 @@ dependencies = [
 [[package]]
 name = "specta-typescript"
 version = "0.0.13"
-source = "git+https://github.com/specta-rs/specta.git?rev=3c535739ea7bd8737ecdbff6c3aef9b7330da706#3c535739ea7bd8737ecdbff6c3aef9b7330da706"
+source = "git+https://github.com/specta-rs/specta.git?rev=c297f26c478766d1cdec11fc804b43f98e8932ad#c297f26c478766d1cdec11fc804b43f98e8932ad"
 dependencies = [
  "specta",
 ]
@@ -2970,7 +2970,7 @@ dependencies = [
 [[package]]
 name = "specta-util"
 version = "0.0.13"
-source = "git+https://github.com/specta-rs/specta.git?rev=3c535739ea7bd8737ecdbff6c3aef9b7330da706#3c535739ea7bd8737ecdbff6c3aef9b7330da706"
+source = "git+https://github.com/specta-rs/specta.git?rev=c297f26c478766d1cdec11fc804b43f98e8932ad#c297f26c478766d1cdec11fc804b43f98e8932ad"
 dependencies = [
  "specta",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,8 +78,8 @@ specta-util = { version = "0.0.13" }
 
 # TODO: Remove once the rc.26 Specta crates are published.
 [patch.crates-io]
-specta = { git = "https://github.com/specta-rs/specta.git", rev = "3c535739ea7bd8737ecdbff6c3aef9b7330da706" }
-specta-macros = { git = "https://github.com/specta-rs/specta.git", rev = "3c535739ea7bd8737ecdbff6c3aef9b7330da706" }
-specta-serde = { git = "https://github.com/specta-rs/specta.git", rev = "3c535739ea7bd8737ecdbff6c3aef9b7330da706" }
-specta-typescript = { git = "https://github.com/specta-rs/specta.git", rev = "3c535739ea7bd8737ecdbff6c3aef9b7330da706" }
-specta-util = { git = "https://github.com/specta-rs/specta.git", rev = "3c535739ea7bd8737ecdbff6c3aef9b7330da706" }
+specta = { git = "https://github.com/specta-rs/specta.git", rev = "c297f26c478766d1cdec11fc804b43f98e8932ad" }
+specta-macros = { git = "https://github.com/specta-rs/specta.git", rev = "c297f26c478766d1cdec11fc804b43f98e8932ad" }
+specta-serde = { git = "https://github.com/specta-rs/specta.git", rev = "c297f26c478766d1cdec11fc804b43f98e8932ad" }
+specta-typescript = { git = "https://github.com/specta-rs/specta.git", rev = "c297f26c478766d1cdec11fc804b43f98e8932ad" }
+specta-util = { git = "https://github.com/specta-rs/specta.git", rev = "c297f26c478766d1cdec11fc804b43f98e8932ad" }

--- a/src/lang/js_ts.rs
+++ b/src/lang/js_ts.rs
@@ -512,8 +512,9 @@ fn runtime(
 
         out.push_str("\n/** Commands */");
         out.push_str("\nexport const commands = ");
-        out.push_str(&match &s.build() {
-            DataType::Reference(r) => exporter.reference(r)?,
+        let commands = s.build();
+        out.push_str(&match &commands {
+            DataType::Reference(_) => exporter.reference(&commands)?,
             dt => exporter.inline(dt)?,
         });
         out.push_str(";\n");
@@ -990,20 +991,13 @@ fn render_reference_dt(dt: &DataType, exporter: &FrameworkExporter) -> Result<St
             NamedReferenceType::Inline { .. } | NamedReferenceType::Recursive(_) => &[],
         };
         let generic = if let Some((_, dt)) = generics.first() {
-            match &dt {
-                DataType::Reference(r) => exporter.reference(r)?,
-                dt => exporter.inline(dt)?,
-            }
-            .into()
+            exporter.reference(dt)?.into()
         } else {
             Cow::Borrowed("never")
         };
         Ok(format!("Channel<{generic}>"))
     } else {
-        match &dt {
-            DataType::Reference(r) => exporter.reference(r),
-            dt => exporter.inline(dt),
-        }
+        exporter.reference(dt)
     }
 }
 

--- a/src/lang/js_ts.rs
+++ b/src/lang/js_ts.rs
@@ -512,11 +512,7 @@ fn runtime(
 
         out.push_str("\n/** Commands */");
         out.push_str("\nexport const commands = ");
-        let commands = s.build();
-        out.push_str(&match &commands {
-            DataType::Reference(_) => exporter.reference(&commands)?,
-            dt => exporter.inline(dt)?,
-        });
+        out.push_str(&exporter.reference(&s.build())?);
         out.push_str(";\n");
     }
 
@@ -608,7 +604,7 @@ fn runtime(
 
         out.push_str("\n/** Events */");
         out.push_str("\nexport const events = ");
-        out.push_str(&exporter.inline(&s.build())?);
+        out.push_str(&exporter.reference(&s.build())?);
         out.push_str(";\n");
     }
 

--- a/tests/option_type_references.rs
+++ b/tests/option_type_references.rs
@@ -1,0 +1,90 @@
+#![allow(missing_docs)]
+#![cfg(feature = "typescript")]
+
+use specta::Type;
+use tauri_specta::{Builder, collect_commands};
+
+#[derive(serde::Serialize, serde::Deserialize, Type)]
+struct Thing {
+    id: u32,
+    name: String,
+    tags: Vec<String>,
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Type)]
+#[specta(inline)]
+struct InlineThing {
+    id: u32,
+}
+
+#[tauri::command]
+#[specta::specta]
+fn bare(thing: Thing) -> Thing {
+    thing
+}
+
+#[tauri::command]
+#[specta::specta]
+fn optional(thing: Option<Thing>) -> Option<Thing> {
+    thing
+}
+
+#[tauri::command]
+#[specta::specta]
+fn optional_inline(thing: Option<InlineThing>) -> Option<InlineThing> {
+    thing
+}
+
+#[tauri::command]
+#[specta::specta]
+fn listed(thing: Vec<Thing>) -> Vec<Thing> {
+    thing
+}
+
+#[tauri::command]
+#[specta::specta]
+fn resulted() -> Result<Option<Thing>, String> {
+    unimplemented!()
+}
+
+// Regression coverage for https://github.com/specta-rs/tauri-specta/issues/228.
+#[test]
+fn named_types_inside_options_are_referenced() {
+    let path = std::env::temp_dir().join(format!(
+        "tauri-specta-option-type-references-{}.ts",
+        std::process::id()
+    ));
+
+    Builder::<tauri::Wry>::new()
+        .commands(collect_commands![
+            bare,
+            optional,
+            optional_inline,
+            listed,
+            resulted
+        ])
+        .export(specta_typescript::Typescript::default(), &path)
+        .expect("bindings export should succeed");
+
+    let bindings = std::fs::read_to_string(&path).expect("bindings should be readable");
+    std::fs::remove_file(path).expect("temporary bindings should be removable");
+
+    assert!(bindings.contains("bare: (thing: Thing)"), "{bindings}");
+    assert!(
+        bindings.contains("optional: (thing: Thing | null)"),
+        "{bindings}"
+    );
+    assert!(
+        bindings.contains("__TAURI_INVOKE<Thing | null>(\"optional\""),
+        "{bindings}"
+    );
+    assert!(
+        bindings.contains("optionalInline: (thing: {\n\tid: number,\n} | null)"),
+        "{bindings}"
+    );
+    assert!(bindings.contains("listed: (thing: Thing[])"), "{bindings}");
+    assert!(
+        bindings.contains("typedError<Thing | null, string>("),
+        "{bindings}"
+    );
+}


### PR DESCRIPTION
## Summary

- render phase-selected composite datatypes through the restored upstream `FrameworkExporter::reference(&DataType)` API
- preserve ordinary named references recursively while retaining explicitly inline behavior and the Tauri channel special case
- add regression coverage for bare, optional, listed, explicitly inline, and `Result<Option<_>, _>` command types

## Root cause

The phase-aware formatter retained `Thing` as a named reference inside `Option<Thing>`, but tauri-specta had to send the surrounding nullable datatype through `FrameworkExporter::inline`. That recursively expanded the nested named type.

This draft pins the Specta workspace patches to specta-rs/specta#539 at commit `c297f26c478766d1cdec11fc804b43f98e8932ad`, pending the upstream merge and release. With that restored API, tauri-specta can pass the complete datatype directly to reference-preserving rendering.

Fixes #228.

## Related work

- Upstream API: specta-rs/specta#539
- This supersedes and simplifies the downstream workaround in #234. It avoids the recursive remapper and opaque TypeScript definition workaround; #234 is otherwise unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --test option_type_references`
- `cargo test --features typescript --test option_type_references`
- `cargo build --all-features`
- `cargo test --all-features`
- `cargo clippy --all-features` (passes with two pre-existing warnings: missing `tauri-specta-query` readme metadata and `src/commands.rs` type complexity)
- independent review and confirming re-review: clean
