### PR TITLE
Respect Serde renames in runtime name checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2929,7 +2929,7 @@ dependencies = [
 [[package]]
 name = "specta"
 version = "2.0.0-rc.26"
-source = "git+https://github.com/specta-rs/specta.git?rev=c297f26c478766d1cdec11fc804b43f98e8932ad#c297f26c478766d1cdec11fc804b43f98e8932ad"
+source = "git+https://github.com/specta-rs/specta.git?rev=2757fa8899926dce7da999780c7edf2dc08a732a#2757fa8899926dce7da999780c7edf2dc08a732a"
 dependencies = [
  "bytes",
  "chrono",
@@ -2942,7 +2942,7 @@ dependencies = [
 [[package]]
 name = "specta-macros"
 version = "2.0.0-rc.26"
-source = "git+https://github.com/specta-rs/specta.git?rev=c297f26c478766d1cdec11fc804b43f98e8932ad#c297f26c478766d1cdec11fc804b43f98e8932ad"
+source = "git+https://github.com/specta-rs/specta.git?rev=2757fa8899926dce7da999780c7edf2dc08a732a#2757fa8899926dce7da999780c7edf2dc08a732a"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -2953,7 +2953,7 @@ dependencies = [
 [[package]]
 name = "specta-serde"
 version = "0.0.13"
-source = "git+https://github.com/specta-rs/specta.git?rev=c297f26c478766d1cdec11fc804b43f98e8932ad#c297f26c478766d1cdec11fc804b43f98e8932ad"
+source = "git+https://github.com/specta-rs/specta.git?rev=2757fa8899926dce7da999780c7edf2dc08a732a#2757fa8899926dce7da999780c7edf2dc08a732a"
 dependencies = [
  "specta",
  "specta-macros",
@@ -2962,7 +2962,7 @@ dependencies = [
 [[package]]
 name = "specta-typescript"
 version = "0.0.13"
-source = "git+https://github.com/specta-rs/specta.git?rev=c297f26c478766d1cdec11fc804b43f98e8932ad#c297f26c478766d1cdec11fc804b43f98e8932ad"
+source = "git+https://github.com/specta-rs/specta.git?rev=2757fa8899926dce7da999780c7edf2dc08a732a#2757fa8899926dce7da999780c7edf2dc08a732a"
 dependencies = [
  "specta",
 ]
@@ -2970,7 +2970,7 @@ dependencies = [
 [[package]]
 name = "specta-util"
 version = "0.0.13"
-source = "git+https://github.com/specta-rs/specta.git?rev=c297f26c478766d1cdec11fc804b43f98e8932ad#c297f26c478766d1cdec11fc804b43f98e8932ad"
+source = "git+https://github.com/specta-rs/specta.git?rev=2757fa8899926dce7da999780c7edf2dc08a732a#2757fa8899926dce7da999780c7edf2dc08a732a"
 dependencies = [
  "specta",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,8 +79,8 @@ specta-util = { version = "0.0.13" }
 
 # TODO: Remove once the rc.26 Specta crates are published.
 [patch.crates-io]
-specta = { git = "https://github.com/specta-rs/specta.git", rev = "c297f26c478766d1cdec11fc804b43f98e8932ad" }
-specta-macros = { git = "https://github.com/specta-rs/specta.git", rev = "c297f26c478766d1cdec11fc804b43f98e8932ad" }
-specta-serde = { git = "https://github.com/specta-rs/specta.git", rev = "c297f26c478766d1cdec11fc804b43f98e8932ad" }
-specta-typescript = { git = "https://github.com/specta-rs/specta.git", rev = "c297f26c478766d1cdec11fc804b43f98e8932ad" }
-specta-util = { git = "https://github.com/specta-rs/specta.git", rev = "c297f26c478766d1cdec11fc804b43f98e8932ad" }
+specta = { git = "https://github.com/specta-rs/specta.git", rev = "2757fa8899926dce7da999780c7edf2dc08a732a" }
+specta-macros = { git = "https://github.com/specta-rs/specta.git", rev = "2757fa8899926dce7da999780c7edf2dc08a732a" }
+specta-serde = { git = "https://github.com/specta-rs/specta.git", rev = "2757fa8899926dce7da999780c7edf2dc08a732a" }
+specta-typescript = { git = "https://github.com/specta-rs/specta.git", rev = "2757fa8899926dce7da999780c7edf2dc08a732a" }
+specta-util = { git = "https://github.com/specta-rs/specta.git", rev = "2757fa8899926dce7da999780c7edf2dc08a732a" }

--- a/src/lang/js_ts.rs
+++ b/src/lang/js_ts.rs
@@ -100,7 +100,7 @@ fn runtime(
 
     let mut out = String::new();
 
-    if let Some(ndt) = cfg
+    if let Some(ndt) = exporter
         .types
         .into_unsorted_iter()
         .find(|ndt| RESERVED_NDT_NAMES.contains(&&*ndt.name))
@@ -1268,13 +1268,13 @@ function makeEvent(name, serialize, deserialize) {
 mod tests {
     use std::fs;
 
-    use serde::Serialize;
+    use serde::{Deserialize, Serialize};
     use specta::{
         Type,
         datatype::{DataType, Primitive},
         specta,
     };
-    use specta_typescript::{JSDoc, Typescript};
+    use specta_typescript::{JSDoc, Layout, Typescript};
 
     use crate::{Builder, ErrorHandlingMode, collect_commands};
 
@@ -1298,6 +1298,23 @@ mod tests {
 
     #[derive(Serialize, Type)]
     struct SemanticError(String);
+
+    #[derive(Serialize, Deserialize, Type)]
+    #[serde(rename = "BuildChannel")]
+    #[allow(dead_code)]
+    enum Channel {
+        Production,
+    }
+
+    mod unrenamed {
+        use super::*;
+
+        #[derive(Serialize, Deserialize, Type)]
+        #[allow(dead_code)]
+        pub enum Channel {
+            Production,
+        }
+    }
 
     #[derive(Serialize, Type)]
     #[serde(untagged)]
@@ -1335,6 +1352,57 @@ mod tests {
     #[specta]
     fn semantic_nullable_error() -> Result<String, SemanticError> {
         Ok(String::new())
+    }
+
+    #[test]
+    fn reserved_runtime_names_use_formatted_type_names() {
+        let output_dir = std::env::temp_dir().join(format!(
+            "tauri-specta-reserved-runtime-names-test-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&output_dir);
+
+        let builder = Builder::<tauri::Wry>::new().typ::<Channel>();
+        for (name, layout) in [
+            ("flat", Layout::FlatFile),
+            ("namespaces", Layout::Namespaces),
+            ("module-prefixed", Layout::ModulePrefixedName),
+            ("files", Layout::Files),
+        ] {
+            let path = output_dir.join(format!("typescript-{name}"));
+            builder
+                .export(Typescript::default().layout(layout), path)
+                .expect("serde-renamed Channel should export as TypeScript");
+            if layout == Layout::FlatFile {
+                let output = fs::read_to_string(output_dir.join("typescript-flat"))
+                    .expect("failed to read TypeScript bindings");
+                assert!(output.contains("export type BuildChannel"));
+            }
+        }
+
+        for (name, layout) in [
+            ("flat", Layout::FlatFile),
+            ("module-prefixed", Layout::ModulePrefixedName),
+            ("files", Layout::Files),
+        ] {
+            let path = output_dir.join(format!("jsdoc-{name}"));
+            builder
+                .export(JSDoc::default().layout(layout), path)
+                .expect("serde-renamed Channel should export as JSDoc");
+            if layout == Layout::FlatFile {
+                let output = fs::read_to_string(output_dir.join("jsdoc-flat"))
+                    .expect("failed to read JSDoc bindings");
+                assert!(output.contains("BuildChannel"));
+            }
+        }
+
+        let err = Builder::<tauri::Wry>::new()
+            .typ::<unrenamed::Channel>()
+            .export(Typescript::default(), output_dir.join("unrenamed.ts"))
+            .expect_err("an exported type named Channel should conflict with the runtime");
+        assert!(err.to_string().contains("User defined type 'Channel'"));
+
+        fs::remove_dir_all(output_dir).expect("failed to remove test output directory");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- validate reserved runtime names against the formatted type graph exposed by `FrameworkExporter`
- add regression coverage for a `Channel` enum symmetrically renamed to `BuildChannel` with Serde
- retain rejection of a user type whose effective exported name is still `Channel`
- advance the existing Specta patch pin to the first mainline reference-rendering commit that also includes enum container rename formatting

## Reproduction

```rust
#[derive(serde::Serialize, serde::Deserialize, specta::Type)]
#[serde(rename = "BuildChannel")]
enum Channel {
    Production,
}
```

Registering this type with `Builder::typ` previously failed with:

```text
User defined type 'Channel' ... must be renamed so it doesn't conflict with Tauri Specta runtime.
```

The exported TypeScript name is `BuildChannel`, so there is no runtime collision and no duplicate `#[specta(rename = "BuildChannel")]` should be required.

## Root cause

The reserved-name check in `src/lang/js_ts.rs::runtime` iterated `cfg.types`, which is the unformatted Specta graph. Serde container renames are applied later by `specta-serde`; the runtime callback already receives that effective graph as `FrameworkExporter::types`.

The repository's prior Specta pin was on a release-side reference-rendering commit from before enum container renames were handled. The updated pin uses the corresponding mainline reference-rendering commit after that serde fix, allowing this enum reproducer to verify the tauri-specta fix end to end.

## Tests

The regression test verifies successful exports for all supported shared-runtime combinations:

- TypeScript: flat file, namespaces, module-prefixed names, and files
- JSDoc: flat file, module-prefixed names, and files

It asserts the emitted type is named `BuildChannel` and separately verifies that an effective exported `Channel` still fails.

Validation run:

- `cargo fmt --all -- --check`
- `cargo test --all-features`
- `cargo clippy --all-features`
