### PR TITLE
Respect effective runtime type names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2929,7 +2929,7 @@ dependencies = [
 [[package]]
 name = "specta"
 version = "2.0.0-rc.26"
-source = "git+https://github.com/specta-rs/specta.git?rev=c297f26c478766d1cdec11fc804b43f98e8932ad#c297f26c478766d1cdec11fc804b43f98e8932ad"
+source = "git+https://github.com/specta-rs/specta.git?rev=2757fa8899926dce7da999780c7edf2dc08a732a#2757fa8899926dce7da999780c7edf2dc08a732a"
 dependencies = [
  "bytes",
  "chrono",
@@ -2942,7 +2942,7 @@ dependencies = [
 [[package]]
 name = "specta-macros"
 version = "2.0.0-rc.26"
-source = "git+https://github.com/specta-rs/specta.git?rev=c297f26c478766d1cdec11fc804b43f98e8932ad#c297f26c478766d1cdec11fc804b43f98e8932ad"
+source = "git+https://github.com/specta-rs/specta.git?rev=2757fa8899926dce7da999780c7edf2dc08a732a#2757fa8899926dce7da999780c7edf2dc08a732a"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -2953,7 +2953,7 @@ dependencies = [
 [[package]]
 name = "specta-serde"
 version = "0.0.13"
-source = "git+https://github.com/specta-rs/specta.git?rev=c297f26c478766d1cdec11fc804b43f98e8932ad#c297f26c478766d1cdec11fc804b43f98e8932ad"
+source = "git+https://github.com/specta-rs/specta.git?rev=2757fa8899926dce7da999780c7edf2dc08a732a#2757fa8899926dce7da999780c7edf2dc08a732a"
 dependencies = [
  "specta",
  "specta-macros",
@@ -2962,7 +2962,7 @@ dependencies = [
 [[package]]
 name = "specta-typescript"
 version = "0.0.13"
-source = "git+https://github.com/specta-rs/specta.git?rev=c297f26c478766d1cdec11fc804b43f98e8932ad#c297f26c478766d1cdec11fc804b43f98e8932ad"
+source = "git+https://github.com/specta-rs/specta.git?rev=2757fa8899926dce7da999780c7edf2dc08a732a#2757fa8899926dce7da999780c7edf2dc08a732a"
 dependencies = [
  "specta",
 ]
@@ -2970,7 +2970,7 @@ dependencies = [
 [[package]]
 name = "specta-util"
 version = "0.0.13"
-source = "git+https://github.com/specta-rs/specta.git?rev=c297f26c478766d1cdec11fc804b43f98e8932ad#c297f26c478766d1cdec11fc804b43f98e8932ad"
+source = "git+https://github.com/specta-rs/specta.git?rev=2757fa8899926dce7da999780c7edf2dc08a732a#2757fa8899926dce7da999780c7edf2dc08a732a"
 dependencies = [
  "specta",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,8 +79,8 @@ specta-util = { version = "0.0.13" }
 
 # TODO: Remove once the rc.26 Specta crates are published.
 [patch.crates-io]
-specta = { git = "https://github.com/specta-rs/specta.git", rev = "c297f26c478766d1cdec11fc804b43f98e8932ad" }
-specta-macros = { git = "https://github.com/specta-rs/specta.git", rev = "c297f26c478766d1cdec11fc804b43f98e8932ad" }
-specta-serde = { git = "https://github.com/specta-rs/specta.git", rev = "c297f26c478766d1cdec11fc804b43f98e8932ad" }
-specta-typescript = { git = "https://github.com/specta-rs/specta.git", rev = "c297f26c478766d1cdec11fc804b43f98e8932ad" }
-specta-util = { git = "https://github.com/specta-rs/specta.git", rev = "c297f26c478766d1cdec11fc804b43f98e8932ad" }
+specta = { git = "https://github.com/specta-rs/specta.git", rev = "2757fa8899926dce7da999780c7edf2dc08a732a" }
+specta-macros = { git = "https://github.com/specta-rs/specta.git", rev = "2757fa8899926dce7da999780c7edf2dc08a732a" }
+specta-serde = { git = "https://github.com/specta-rs/specta.git", rev = "2757fa8899926dce7da999780c7edf2dc08a732a" }
+specta-typescript = { git = "https://github.com/specta-rs/specta.git", rev = "2757fa8899926dce7da999780c7edf2dc08a732a" }
+specta-util = { git = "https://github.com/specta-rs/specta.git", rev = "2757fa8899926dce7da999780c7edf2dc08a732a" }

--- a/src/lang/js_ts.rs
+++ b/src/lang/js_ts.rs
@@ -8,7 +8,7 @@ use specta::{
     },
 };
 use specta_serde::Phase;
-use specta_typescript::{Error, Exporter, FrameworkExporter, define, semantic};
+use specta_typescript::{Error, Exporter, FrameworkExporter, Layout, define, semantic};
 use specta_util::Remapper;
 
 use crate::name::{resolve_tauri_command_name, resolve_tauri_event_name};
@@ -100,16 +100,16 @@ fn runtime(
 
     let mut out = String::new();
 
-    if let Some(ndt) = cfg
-        .types
-        .into_unsorted_iter()
-        .find(|ndt| RESERVED_NDT_NAMES.contains(&&*ndt.name))
-    {
+    if let Some((ndt, name)) = exporter.types.into_unsorted_iter().find_map(|ndt| {
+        runtime_scope_name(exporter.layout, ndt)
+            .filter(|name| RESERVED_NDT_NAMES.contains(&name.as_ref()))
+            .map(|name| (ndt, name))
+    }) {
         return Err(Error::framework(
             "",
             format!(
                 "User defined type '{}' defined in {} must be renamed so it doesn't conflict with Tauri Specta runtime.",
-                ndt.name, ndt.location
+                name, ndt.location
             ),
         ));
     }
@@ -704,6 +704,25 @@ fn runtime(
     Ok(Cow::Owned(out))
 }
 
+fn runtime_scope_name(layout: Layout, ndt: &NamedDataType) -> Option<Cow<'static, str>> {
+    match layout {
+        Layout::FlatFile => Some(ndt.name.clone()),
+        Layout::ModulePrefixedName => Some(Cow::Owned(format!(
+            "{}_{}",
+            ndt.module_path.replace("::", "_"),
+            ndt.name
+        ))),
+        Layout::Namespaces => Some(
+            ndt.module_path
+                .split("::")
+                .next()
+                .filter(|module| !module.is_empty())
+                .map_or_else(|| ndt.name.clone(), |module| Cow::Owned(module.to_owned())),
+        ),
+        Layout::Files => ndt.module_path.is_empty().then(|| ndt.name.clone()),
+    }
+}
+
 /// Applies `specta_serde` format + also remaps `DataType`'s and does other transformations!
 #[derive(Debug, Clone)]
 struct SpectaFormat {
@@ -1268,13 +1287,13 @@ function makeEvent(name, serialize, deserialize) {
 mod tests {
     use std::fs;
 
-    use serde::Serialize;
+    use serde::{Deserialize, Serialize};
     use specta::{
         Type,
         datatype::{DataType, Primitive},
         specta,
     };
-    use specta_typescript::{JSDoc, Typescript};
+    use specta_typescript::{JSDoc, Layout, Typescript};
 
     use crate::{Builder, ErrorHandlingMode, collect_commands};
 
@@ -1298,6 +1317,23 @@ mod tests {
 
     #[derive(Serialize, Type)]
     struct SemanticError(String);
+
+    #[derive(Serialize, Deserialize, Type)]
+    #[serde(rename = "BuildChannel")]
+    #[allow(dead_code)]
+    enum Channel {
+        Production,
+    }
+
+    mod unrenamed {
+        use super::*;
+
+        #[derive(Serialize, Deserialize, Type)]
+        #[allow(dead_code)]
+        pub enum Channel {
+            Production,
+        }
+    }
 
     #[derive(Serialize, Type)]
     #[serde(untagged)]
@@ -1335,6 +1371,81 @@ mod tests {
     #[specta]
     fn semantic_nullable_error() -> Result<String, SemanticError> {
         Ok(String::new())
+    }
+
+    #[test]
+    fn reserved_runtime_names_use_exported_type_names() {
+        let output_dir = std::path::Path::new("target/tests/reserved-runtime-names");
+        let _ = fs::remove_dir_all(output_dir);
+
+        let renamed = Builder::<tauri::Wry>::new().typ::<Channel>();
+        for (name, layout) in [
+            ("flat", Layout::FlatFile),
+            ("namespaces", Layout::Namespaces),
+            ("module-prefixed", Layout::ModulePrefixedName),
+            ("files", Layout::Files),
+        ] {
+            renamed
+                .export(Typescript::default().layout(layout), output_dir.join(name))
+                .expect("serde-renamed Channel should export as TypeScript");
+        }
+        assert!(
+            fs::read_to_string(output_dir.join("flat"))
+                .expect("failed to read TypeScript bindings")
+                .contains("export type BuildChannel")
+        );
+
+        for (name, layout) in [
+            ("jsdoc-flat", Layout::FlatFile),
+            ("jsdoc-module-prefixed", Layout::ModulePrefixedName),
+            ("jsdoc-files", Layout::Files),
+        ] {
+            renamed
+                .export(JSDoc::default().layout(layout), output_dir.join(name))
+                .expect("serde-renamed Channel should export as JSDoc");
+        }
+        assert!(
+            fs::read_to_string(output_dir.join("jsdoc-flat"))
+                .expect("failed to read JSDoc bindings")
+                .contains("BuildChannel")
+        );
+
+        let err = Builder::<tauri::Wry>::new()
+            .typ::<unrenamed::Channel>()
+            .export(Typescript::default(), output_dir.join("unrenamed.ts"))
+            .expect_err("a flat export named Channel should conflict with the runtime");
+        assert!(err.to_string().contains("User defined type 'Channel'"));
+
+        Builder::<tauri::Wry>::new()
+            .typ::<unrenamed::Channel>()
+            .export(JSDoc::default(), output_dir.join("unrenamed.js"))
+            .expect_err("a flat JSDoc export named Channel should conflict with the runtime");
+
+        for (name, layout) in [
+            ("unrenamed-namespaces", Layout::Namespaces),
+            ("unrenamed-module-prefixed", Layout::ModulePrefixedName),
+            ("unrenamed-files", Layout::Files),
+        ] {
+            Builder::<tauri::Wry>::new()
+                .typ::<unrenamed::Channel>()
+                .export(Typescript::default().layout(layout), output_dir.join(name))
+                .expect("a scoped Channel should not conflict with the runtime");
+        }
+
+        for (name, layout) in [
+            (
+                "unrenamed-jsdoc-module-prefixed",
+                Layout::ModulePrefixedName,
+            ),
+            ("unrenamed-jsdoc-files", Layout::Files),
+        ] {
+            Builder::<tauri::Wry>::new()
+                .typ::<unrenamed::Channel>()
+                .export(JSDoc::default().layout(layout), output_dir.join(name))
+                .expect("a scoped Channel should not conflict with the JSDoc runtime");
+        }
+
+        fs::remove_dir_all(output_dir).expect("failed to remove test output directory");
     }
 
     #[test]

--- a/src/lang/js_ts.rs
+++ b/src/lang/js_ts.rs
@@ -105,7 +105,7 @@ fn runtime(
         .into_unsorted_iter()
         .filter(|ndt| ndt.ty.is_some())
         .find_map(|ndt| {
-            runtime_scope_name(exporter.layout, ndt)
+            runtime_scope_name(jsdoc, exporter.layout, ndt)
                 .filter(|name| RESERVED_NDT_NAMES.contains(&name.as_ref()))
                 .map(|name| (ndt, name))
         })
@@ -709,22 +709,26 @@ fn runtime(
     Ok(Cow::Owned(out))
 }
 
-fn runtime_scope_name(layout: Layout, ndt: &NamedDataType) -> Option<Cow<'static, str>> {
-    match layout {
-        Layout::FlatFile => Some(ndt.name.clone()),
-        Layout::ModulePrefixedName => Some(Cow::Owned(format!(
+fn runtime_scope_name(
+    jsdoc: bool,
+    layout: Layout,
+    ndt: &NamedDataType,
+) -> Option<Cow<'static, str>> {
+    match (jsdoc, layout) {
+        (_, Layout::FlatFile) | (true, Layout::ModulePrefixedName) => Some(ndt.name.clone()),
+        (false, Layout::ModulePrefixedName) => Some(Cow::Owned(format!(
             "{}_{}",
             ndt.module_path.replace("::", "_"),
             ndt.name
         ))),
-        Layout::Namespaces => Some(
+        (_, Layout::Namespaces) => Some(
             ndt.module_path
                 .split("::")
                 .next()
                 .filter(|module| !module.is_empty())
                 .map_or_else(|| ndt.name.clone(), |module| Cow::Owned(module.to_owned())),
         ),
-        Layout::Files => ndt.module_path.is_empty().then(|| ndt.name.clone()),
+        (_, Layout::Files) => ndt.module_path.is_empty().then(|| ndt.name.clone()),
     }
 }
 
@@ -1458,18 +1462,21 @@ mod tests {
                 .expect("a scoped Channel should not conflict with the runtime");
         }
 
-        for (name, layout) in [
-            (
-                "unrenamed-jsdoc-module-prefixed",
-                Layout::ModulePrefixedName,
-            ),
-            ("unrenamed-jsdoc-files", Layout::Files),
-        ] {
-            Builder::<tauri::Wry>::new()
-                .typ::<unrenamed::Channel>()
-                .export(JSDoc::default().layout(layout), output_dir.join(name))
-                .expect("a scoped Channel should not conflict with the JSDoc runtime");
-        }
+        Builder::<tauri::Wry>::new()
+            .typ::<unrenamed::Channel>()
+            .export(
+                JSDoc::default().layout(Layout::ModulePrefixedName),
+                output_dir.join("unrenamed-jsdoc-module-prefixed"),
+            )
+            .expect_err("JSDoc module-prefixed typedefs should retain their bare names");
+
+        Builder::<tauri::Wry>::new()
+            .typ::<unrenamed::Channel>()
+            .export(
+                JSDoc::default().layout(Layout::Files),
+                output_dir.join("unrenamed-jsdoc-files"),
+            )
+            .expect("a Channel in a separate JSDoc file should not conflict with the runtime");
 
         fs::remove_dir_all(output_dir).expect("failed to remove test output directory");
     }

--- a/src/lang/js_ts.rs
+++ b/src/lang/js_ts.rs
@@ -100,11 +100,16 @@ fn runtime(
 
     let mut out = String::new();
 
-    if let Some((ndt, name)) = exporter.types.into_unsorted_iter().find_map(|ndt| {
-        runtime_scope_name(exporter.layout, ndt)
-            .filter(|name| RESERVED_NDT_NAMES.contains(&name.as_ref()))
-            .map(|name| (ndt, name))
-    }) {
+    if let Some((ndt, name)) = exporter
+        .types
+        .into_unsorted_iter()
+        .filter(|ndt| ndt.ty.is_some())
+        .find_map(|ndt| {
+            runtime_scope_name(exporter.layout, ndt)
+                .filter(|name| RESERVED_NDT_NAMES.contains(&name.as_ref()))
+                .map(|name| (ndt, name))
+        })
+    {
         return Err(Error::framework(
             "",
             format!(
@@ -1335,6 +1340,16 @@ mod tests {
         }
     }
 
+    mod inline {
+        use super::*;
+
+        #[derive(Serialize, Deserialize, Type)]
+        #[specta(inline)]
+        pub struct Channel {
+            value: String,
+        }
+    }
+
     #[derive(Serialize, Type)]
     #[serde(untagged)]
     #[allow(dead_code)]
@@ -1408,6 +1423,17 @@ mod tests {
             fs::read_to_string(output_dir.join("jsdoc-flat"))
                 .expect("failed to read JSDoc bindings")
                 .contains("BuildChannel")
+        );
+
+        let inline_path = output_dir.join("inline.ts");
+        Builder::<tauri::Wry>::new()
+            .typ::<inline::Channel>()
+            .export(Typescript::default(), &inline_path)
+            .expect("an inline type named Channel should not conflict with the runtime");
+        assert!(
+            !fs::read_to_string(inline_path)
+                .expect("failed to read inline TypeScript bindings")
+                .contains("export type Channel")
         );
 
         let err = Builder::<tauri::Wry>::new()


### PR DESCRIPTION
## Summary

- validate reserved runtime names against the formatted type graph exposed by `FrameworkExporter`
- compare the name that is actually emitted into the runtime scope for each TypeScript layout
- keep rejecting real runtime-scope collisions while allowing Serde-renamed and separately scoped types
- update the Specta pin to include symmetric enum-container rename formatting

## Reproduction

```rust
#[derive(serde::Serialize, serde::Deserialize, specta::Type)]
#[serde(rename = "BuildChannel")]
enum Channel {
    Production,
}
```

Registering this type with `Builder::typ` previously failed with a message that the user-defined `Channel` conflicted with the Tauri Specta runtime. Its effective TypeScript name is `BuildChannel`, so no collision exists and a duplicate `#[specta(rename = "BuildChannel")]` should not be required.

## Root cause

The reserved-name check in `src/lang/js_ts.rs::runtime` iterated `cfg.types`, the unformatted Specta graph. Symmetric Serde container renames are applied during formatting, and the runtime callback receives that effective graph through `FrameworkExporter::types`.

The check also needs to account for layout: flat types share the runtime scope, module-prefixed types use their prefixed export name, namespace exports expose their top-level name, and only root types share the runtime file in the files layout.

## Tests

The regression test verifies:

- successful `BuildChannel` exports for all TypeScript layouts and all JSDoc-supported layouts
- emitted TypeScript and JSDoc output uses `BuildChannel`
- a flat user export genuinely named `Channel` is still rejected in TypeScript and JSDoc
- namespace, module-prefixed, and files layouts allow a `Channel` that does not share the runtime scope

Validation:

- `cargo fmt --all -- --check`
- `cargo test --all-features`
- `cargo clippy --all-features --all-targets -- -D warnings`
- `git diff --check`
