### PR TITLE
Avoid repeated mapper spreads for serde aliases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2929,7 +2929,7 @@ dependencies = [
 [[package]]
 name = "specta"
 version = "2.0.0-rc.26"
-source = "git+https://github.com/specta-rs/specta.git?rev=c297f26c478766d1cdec11fc804b43f98e8932ad#c297f26c478766d1cdec11fc804b43f98e8932ad"
+source = "git+https://github.com/specta-rs/specta.git?rev=1e8ce31311205058c502056b6c5a4e20149cb9f1#1e8ce31311205058c502056b6c5a4e20149cb9f1"
 dependencies = [
  "bytes",
  "chrono",
@@ -2942,7 +2942,7 @@ dependencies = [
 [[package]]
 name = "specta-macros"
 version = "2.0.0-rc.26"
-source = "git+https://github.com/specta-rs/specta.git?rev=c297f26c478766d1cdec11fc804b43f98e8932ad#c297f26c478766d1cdec11fc804b43f98e8932ad"
+source = "git+https://github.com/specta-rs/specta.git?rev=1e8ce31311205058c502056b6c5a4e20149cb9f1#1e8ce31311205058c502056b6c5a4e20149cb9f1"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -2953,7 +2953,7 @@ dependencies = [
 [[package]]
 name = "specta-serde"
 version = "0.0.13"
-source = "git+https://github.com/specta-rs/specta.git?rev=c297f26c478766d1cdec11fc804b43f98e8932ad#c297f26c478766d1cdec11fc804b43f98e8932ad"
+source = "git+https://github.com/specta-rs/specta.git?rev=1e8ce31311205058c502056b6c5a4e20149cb9f1#1e8ce31311205058c502056b6c5a4e20149cb9f1"
 dependencies = [
  "specta",
  "specta-macros",
@@ -2962,7 +2962,7 @@ dependencies = [
 [[package]]
 name = "specta-typescript"
 version = "0.0.13"
-source = "git+https://github.com/specta-rs/specta.git?rev=c297f26c478766d1cdec11fc804b43f98e8932ad#c297f26c478766d1cdec11fc804b43f98e8932ad"
+source = "git+https://github.com/specta-rs/specta.git?rev=1e8ce31311205058c502056b6c5a4e20149cb9f1#1e8ce31311205058c502056b6c5a4e20149cb9f1"
 dependencies = [
  "specta",
 ]
@@ -2970,7 +2970,7 @@ dependencies = [
 [[package]]
 name = "specta-util"
 version = "0.0.13"
-source = "git+https://github.com/specta-rs/specta.git?rev=c297f26c478766d1cdec11fc804b43f98e8932ad#c297f26c478766d1cdec11fc804b43f98e8932ad"
+source = "git+https://github.com/specta-rs/specta.git?rev=1e8ce31311205058c502056b6c5a4e20149cb9f1#1e8ce31311205058c502056b6c5a4e20149cb9f1"
 dependencies = [
  "specta",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,8 +79,8 @@ specta-util = { version = "0.0.13" }
 
 # TODO: Remove once the rc.26 Specta crates are published.
 [patch.crates-io]
-specta = { git = "https://github.com/specta-rs/specta.git", rev = "c297f26c478766d1cdec11fc804b43f98e8932ad" }
-specta-macros = { git = "https://github.com/specta-rs/specta.git", rev = "c297f26c478766d1cdec11fc804b43f98e8932ad" }
-specta-serde = { git = "https://github.com/specta-rs/specta.git", rev = "c297f26c478766d1cdec11fc804b43f98e8932ad" }
-specta-typescript = { git = "https://github.com/specta-rs/specta.git", rev = "c297f26c478766d1cdec11fc804b43f98e8932ad" }
-specta-util = { git = "https://github.com/specta-rs/specta.git", rev = "c297f26c478766d1cdec11fc804b43f98e8932ad" }
+specta = { git = "https://github.com/specta-rs/specta.git", rev = "1e8ce31311205058c502056b6c5a4e20149cb9f1" }
+specta-macros = { git = "https://github.com/specta-rs/specta.git", rev = "1e8ce31311205058c502056b6c5a4e20149cb9f1" }
+specta-serde = { git = "https://github.com/specta-rs/specta.git", rev = "1e8ce31311205058c502056b6c5a4e20149cb9f1" }
+specta-typescript = { git = "https://github.com/specta-rs/specta.git", rev = "1e8ce31311205058c502056b6c5a4e20149cb9f1" }
+specta-util = { git = "https://github.com/specta-rs/specta.git", rev = "1e8ce31311205058c502056b6c5a4e20149cb9f1" }


### PR DESCRIPTION
## Summary
- update the patched Specta revision to include semantic intersection mapper deduplication
- prevent alias/phase-generated TypeScript bindings from accumulating identical object spreads

## Root cause
Specta serde aliases can produce intersection branches with identical semantic runtime transforms. The TypeScript semantic generator previously spread every branch, inflating generated command mappers and risking TS2590 for nested alias-heavy types.

Depends on specta-rs/specta#554.

## Validation
- `cargo test -p specta-tests --test test semantic_intersection_deduplicates_identical_runtime_transforms`
- `cargo test --features derive,typescript`