### PR TITLE
fix(query): disable Tauri default features

### DIFF
--- a/crates/tauri-specta-query/Cargo.toml
+++ b/crates/tauri-specta-query/Cargo.toml
@@ -19,7 +19,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 heck = "0.5"
-tauri.workspace = true
+tauri = { version = "2", default-features = false }
 specta.workspace = true
 serde = "1"
 serde_json = "1"


### PR DESCRIPTION
## Summary

- keep tauri-specta-query runtime-agnostic by disabling Tauri default features
- let applications select WRY, CEF, or another runtime explicitly

The workspace-level Tauri dependency currently enables WRY transitively for every query consumer. That makes CEF-only Linux applications compile WebKitGTK unexpectedly.

## Verification

- cargo check -p tauri-specta-query --lib
- cargo tree -p tauri-specta-query -e normal,build,features -i tauri --target x86_64-unknown-linux-gnu