### PR TITLE
Disable Tauri runtime defaults for library crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ tauri-specta-macros = { version = "=2.0.0-rc.25", optional = true, path = "./mac
 serde = "1"
 serde_json = "1"
 thiserror = "2"
-tauri = { version = "2", default-features = false, features = ["specta"] }
+tauri = { workspace = true, features = ["specta"] }
 
 # Private
 heck = "0.5"
@@ -43,7 +43,7 @@ specta-serde = { workspace = true }
 specta-util = { workspace = true }
 
 [dev-dependencies]
-tauri = { version = "2", default-features = false, features = ["test", "wry"] }
+tauri = { workspace = true, features = ["test", "wry"] }
 
 [workspace]
 members = [
@@ -69,7 +69,7 @@ todo = { level = "warn", priority = -1 }
 panic_in_result_fn = { level = "warn", priority = -1 }
 
 [workspace.dependencies]
-tauri = { version = "2" }
+tauri = { version = "2", default-features = false }
 tauri-build = { version = "2" }
 tauri-plugin = { version = "2" }
 specta = { version = "=2.0.0-rc.26", features = ["derive"] }

--- a/examples/app/src-tauri/Cargo.toml
+++ b/examples/app/src-tauri/Cargo.toml
@@ -15,7 +15,7 @@ tauri-build = { workspace = true, features = [] }
 serde_json = "1.0"
 specta = { workspace = true, features = ["bytes", "chrono", "url"] }
 serde = { version = "1.0", features = ["derive"] }
-tauri = { workspace = true, features = [] }
+tauri = { workspace = true, features = ["default"] }
 tauri-specta = { path = "../../../", features = ["derive", "typescript", "javascript"] }
 specta-typescript = { workspace = true }
 tauri-plugin-os = "^2.3.2"

--- a/examples/custom-plugin/app/src-tauri/Cargo.toml
+++ b/examples/custom-plugin/app/src-tauri/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 tauri-build = { workspace = true, features = [] }
 
 [dependencies]
-tauri = { workspace = true, features = [] }
+tauri = { workspace = true, features = ["default"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tauri-plugin-specta-example = { path = "../../plugin" }

--- a/examples/tanstack-query/src-tauri/Cargo.toml
+++ b/examples/tanstack-query/src-tauri/Cargo.toml
@@ -15,7 +15,7 @@ tauri-build = { workspace = true, features = [] }
 serde_json = "1.0"
 specta = { workspace = true, features = ["bytes", "chrono", "url"] }
 serde = { version = "1.0", features = ["derive"] }
-tauri = { workspace = true, features = [] }
+tauri = { workspace = true, features = ["default"] }
 tauri-specta = { path = "../../../", features = ["derive", "typescript", "javascript"] }
 tauri-specta-query = { path = "../../../crates/tauri-specta-query" }
 specta-typescript = { workspace = true }


### PR DESCRIPTION
## Summary

- disable Tauri default features at workspace dependency scope
- make the library crates inherit that runtime-neutral Tauri dependency
- explicitly restore Tauri defaults for runnable example applications

## Root cause

`tauri-specta-query` inherited a workspace Tauri dependency whose default features were enabled. Cargo feature unification therefore selected `wry` for downstream applications even when they explicitly selected another runtime such as CEF.

This caused CEF-only Linux builds to compile `javascriptcore-rs-sys` and require `javascriptcoregtk-4.1`.

## Impact

Library consumers no longer receive Wry or CEF from tauri-specta by default. A consumer's own Tauri dependency remains authoritative: normal Tauri defaults enable Wry transitively, while TAP's patched `tauri/cef` configuration enables CEF without Wry.

## Validation

- `cargo check --locked -p tauri-specta-query --lib`
- `cargo test --locked -p tauri-specta-query --lib`
- isolated consumer graph: tauri-specta alone includes neither Wry nor CEF
- isolated consumer graph: adding default Tauri enables `tauri-runtime-wry`
- exact TAP CEF graph: `tauri-runtime-cef` present and `wry` absent
