### PR TITLE
Remove rustc-args from docs.rs metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ categories = ["web-programming", "asynchronous"]
 # /bin/sh RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features
 [package.metadata."docs.rs"]
 all-features = true
-rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]

--- a/crates/tauri-specta-query/Cargo.toml
+++ b/crates/tauri-specta-query/Cargo.toml
@@ -14,7 +14,6 @@ categories = ["web-programming", "asynchronous"]
 
 [package.metadata."docs.rs"]
 all-features = true
-rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]

--- a/src/lang/js_ts.rs
+++ b/src/lang/js_ts.rs
@@ -119,6 +119,29 @@ fn runtime(
         ));
     }
 
+    {
+        let mut seen = std::collections::BTreeMap::new();
+        for command in cfg.commands.iter() {
+            let accessor = cfg.function_casing.apply(command.name()).into_owned();
+            if let Some(first) = seen.insert(accessor.clone(), command.name()) {
+                return Err(Error::framework(
+                    "",
+                    if first == command.name() {
+                        format!(
+                            "Command '{}' is registered multiple times. Remove the duplicate registration.",
+                            command.name()
+                        )
+                    } else {
+                        format!(
+                            "Commands '{first}' and '{}' would both export as '{accessor}'. Rename one of them so the generated bindings don't conflict.",
+                            command.name()
+                        )
+                    },
+                ));
+            }
+        }
+    }
+
     let is_channel_used = cfg.commands.iter().any(|command| {
         // Check if any argument is a Channel
         command

--- a/tests/duplicate_commands.rs
+++ b/tests/duplicate_commands.rs
@@ -1,0 +1,69 @@
+//! Regression coverage for https://github.com/specta-rs/tauri-specta/issues/115.
+
+#![allow(missing_docs, unused, clippy::unwrap_used)]
+#![cfg(all(feature = "typescript", feature = "derive"))]
+
+use std::fs;
+
+use specta_typescript::Typescript;
+use tauri::test::MockRuntime;
+use tauri_specta::{Builder, collect_commands};
+
+#[tauri::command]
+#[specta::specta]
+fn my_command() {}
+
+#[tauri::command]
+#[specta::specta]
+fn other_command() {}
+
+// Note: two commands with the same name in different modules of one crate can't
+// currently be expressed — specta's generated `__specta__fn__*` macros collide at
+// crate root (the same family as issue #142). The runtime check still covers that
+// case when it arises across crates (e.g. a plugin command clashing with an app one).
+
+#[allow(non_snake_case)]
+#[tauri::command]
+#[specta::specta]
+fn myCommand() {}
+
+fn export(builder: &Builder<MockRuntime>) -> Result<(), specta_typescript::Error> {
+    let dir = std::env::temp_dir().join(format!(
+        "tauri_specta_duplicate_commands_{}_{:?}",
+        std::process::id(),
+        std::thread::current().id()
+    ));
+    fs::create_dir_all(&dir).unwrap();
+    builder.export(Typescript::default(), dir.join("bindings.ts"))
+}
+
+#[test]
+fn distinct_commands_export() {
+    let builder =
+        Builder::<MockRuntime>::new().commands(collect_commands![my_command, other_command]);
+    export(&builder).expect("distinct commands should export");
+}
+
+#[test]
+fn duplicate_registration_errors() {
+    let builder = Builder::<MockRuntime>::new().commands(collect_commands![my_command, my_command]);
+    let err = export(&builder)
+        .expect_err("registering the same command twice should fail to export")
+        .to_string();
+    assert!(
+        err.contains("Command 'my_command' is registered multiple times"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn casing_collision_errors() {
+    let builder = Builder::<MockRuntime>::new().commands(collect_commands![my_command, myCommand]);
+    let err = export(&builder)
+        .expect_err("commands that collide after casing should fail to export")
+        .to_string();
+    assert!(
+        err.contains("Commands 'my_command' and 'myCommand' would both export as 'myCommand'"),
+        "unexpected error: {err}"
+    );
+}


### PR DESCRIPTION
Related: #227 — this fixes the cause going forward; the currently broken rc.25 docs need a one-click rebuild (below).

## What changed

- drop `rustc-args = ["--cfg", "docsrs"]` from `[package.metadata."docs.rs"]` in `tauri-specta` and `tauri-specta-query`, keeping `all-features` and `rustdoc-args`

## Why

The rc.25 docs.rs failure in #227 (full log: [build 3247825](https://docs.rs/crate/tauri-specta/2.0.0-rc.25/builds/3247825)) is:

```
error[E0557]: feature has been removed
  --> winnow-0.5.40/src/lib.rs:49:29
   |
49 | #![cfg_attr(docsrs, feature(doc_auto_cfg))]
   |                             ^^^^^^^^^^^^ feature has been removed
   = note: removed in 1.92.0; see rust-lang/rust#138907 (merged into `doc_cfg`)
```

docs.rs implemented our `rustc-args` by injecting `build.rustflags=["--cfg","docsrs"]`, which applies to **every crate in the graph**, not just this one. On Linux, `tauri` unconditionally pulls the frozen gtk-rs 0.18 chain (`gtk3-macros → proc-macro-crate 1.3 → toml_edit 0.19 → winnow 0.5.40`, plus `toml_datetime 0.6.3` and `serde_spanned 0.6.9`), and those old crates gate the removed `doc_auto_cfg` nightly feature behind `cfg(docsrs)` — so the injected flag detonates them. No fixed releases exist in those lines (the gtk-rs 0.18 line is unmaintained), so they can't be bumped away.

`rustdoc-args` is all this crate actually needs: the `#![cfg_attr(docsrs, feature(doc_cfg))]` gate and the `doc(cfg(...))` badges are processed by rustdoc, which receives `rustdoc-args` for the top crate only. (docs.rs also appears to no longer honor `rustc-args` — tauri 2.11.5's July build log shows no injected rustflags despite tauri declaring `rustc-args` — but removing it makes the build robust regardless of that policy.)

Verified locally with docs.rs's current invocation shape: `RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features --no-deps` builds clean.

## The rc.25 half

The published rc.25 needs a rebuild from the crate's Builds page (owner action) — under current docs.rs behavior it will succeed, which also makes the README's `^2.0.0-rc.21` versioned link resolve to working docs. Happy for this PR plus that rebuild to close #227.
