### PR TITLE
Error on duplicate and colliding command registrations

### DIFF
--- a/src/lang/js_ts.rs
+++ b/src/lang/js_ts.rs
@@ -119,6 +119,29 @@ fn runtime(
         ));
     }
 
+    {
+        let mut seen = std::collections::BTreeMap::new();
+        for command in cfg.commands.iter() {
+            let accessor = cfg.function_casing.apply(command.name()).into_owned();
+            if let Some(first) = seen.insert(accessor.clone(), command.name()) {
+                return Err(Error::framework(
+                    "",
+                    if first == command.name() {
+                        format!(
+                            "Command '{}' is registered multiple times. Remove the duplicate registration.",
+                            command.name()
+                        )
+                    } else {
+                        format!(
+                            "Commands '{first}' and '{}' would both export as '{accessor}'. Rename one of them so the generated bindings don't conflict.",
+                            command.name()
+                        )
+                    },
+                ));
+            }
+        }
+    }
+
     let is_channel_used = cfg.commands.iter().any(|command| {
         // Check if any argument is a Channel
         command

--- a/tests/duplicate_commands.rs
+++ b/tests/duplicate_commands.rs
@@ -1,0 +1,69 @@
+//! Regression coverage for https://github.com/specta-rs/tauri-specta/issues/115.
+
+#![allow(missing_docs, unused, clippy::unwrap_used)]
+#![cfg(all(feature = "typescript", feature = "derive"))]
+
+use std::fs;
+
+use specta_typescript::Typescript;
+use tauri::test::MockRuntime;
+use tauri_specta::{Builder, collect_commands};
+
+#[tauri::command]
+#[specta::specta]
+fn my_command() {}
+
+#[tauri::command]
+#[specta::specta]
+fn other_command() {}
+
+// Note: two commands with the same name in different modules of one crate can't
+// currently be expressed — specta's generated `__specta__fn__*` macros collide at
+// crate root (the same family as issue #142). The runtime check still covers that
+// case when it arises across crates (e.g. a plugin command clashing with an app one).
+
+#[allow(non_snake_case)]
+#[tauri::command]
+#[specta::specta]
+fn myCommand() {}
+
+fn export(builder: &Builder<MockRuntime>) -> Result<(), specta_typescript::Error> {
+    let dir = std::env::temp_dir().join(format!(
+        "tauri_specta_duplicate_commands_{}_{:?}",
+        std::process::id(),
+        std::thread::current().id()
+    ));
+    fs::create_dir_all(&dir).unwrap();
+    builder.export(Typescript::default(), dir.join("bindings.ts"))
+}
+
+#[test]
+fn distinct_commands_export() {
+    let builder =
+        Builder::<MockRuntime>::new().commands(collect_commands![my_command, other_command]);
+    export(&builder).expect("distinct commands should export");
+}
+
+#[test]
+fn duplicate_registration_errors() {
+    let builder = Builder::<MockRuntime>::new().commands(collect_commands![my_command, my_command]);
+    let err = export(&builder)
+        .expect_err("registering the same command twice should fail to export")
+        .to_string();
+    assert!(
+        err.contains("Command 'my_command' is registered multiple times"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn casing_collision_errors() {
+    let builder = Builder::<MockRuntime>::new().commands(collect_commands![my_command, myCommand]);
+    let err = export(&builder)
+        .expect_err("commands that collide after casing should fail to export")
+        .to_string();
+    assert!(
+        err.contains("Commands 'my_command' and 'myCommand' would both export as 'myCommand'"),
+        "unexpected error: {err}"
+    );
+}


### PR DESCRIPTION
Closes #115.

## What changed

- export now fails with a clear message when a command is registered more than once, instead of silently generating a bindings object where the last registration wins
- the check runs on the cased accessor name, so it also catches two differently named commands that collide after `function_casing` is applied (e.g. `my_cmd` and `myCmd` both exporting as `myCmd`), with a message that names both commands and the colliding accessor
- regression tests for both cases plus a passing control

## Why

`commands.myCmd` silently binding to whichever registration came last is a correctness trap — the error surfaces it at export time with the exact names involved.

## Notes

Two same-named commands in *different modules* of one crate currently can't even be constructed — the generated `__specta__fn__*`/`__cmd__*` helper macros collide at crate root (the same family as #142) — so that scenario is only reachable across crates (e.g. a plugin command clashing with an app one), where this check still catches it. Noted in the test file.

## Validation

- `cargo test --all-features` (3 new tests)
- `cargo clippy --all-features --all-targets` (no warnings)
- `cargo fmt --check`
